### PR TITLE
Removed find-links in global section for pip config.

### DIFF
--- a/python/pip-avx-gentoo.conf
+++ b/python/pip-avx-gentoo.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]

--- a/python/pip-avx.conf
+++ b/python/pip-avx.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]

--- a/python/pip-avx2-gentoo.conf
+++ b/python/pip-avx2-gentoo.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]

--- a/python/pip-avx2.conf
+++ b/python/pip-avx2.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]

--- a/python/pip-avx512-gentoo.conf
+++ b/python/pip-avx512-gentoo.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]

--- a/python/pip-avx512.conf
+++ b/python/pip-avx512.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]

--- a/python/pip-generic-gentoo.conf
+++ b/python/pip-generic-gentoo.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]

--- a/python/pip-gentoo.conf
+++ b/python/pip-gentoo.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]

--- a/python/pip-sse3-gentoo.conf
+++ b/python/pip-sse3-gentoo.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]

--- a/python/pip.conf
+++ b/python/pip.conf
@@ -1,5 +1,4 @@
 [global]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
 disable-pip-version-check = true
 
 [wheel]


### PR DESCRIPTION
The option is deprecating.
DEPRECATION: --find-links option in pip freeze is deprecated. pip 21.2 will remove support for this functionality.
You can find discussion regarding this at pypa issue #9069.