### PR TITLE
Remove deprecated `--use-wheel` config option. Pip v10.0.0b1 (2018-03…

### DIFF
--- a/python/pip-avx-gentoo.conf
+++ b/python/pip-avx-gentoo.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /c
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true

--- a/python/pip-avx.conf
+++ b/python/pip-avx.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx /cvmf
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true

--- a/python/pip-avx2-gentoo.conf
+++ b/python/pip-avx2-gentoo.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true

--- a/python/pip-avx2.conf
+++ b/python/pip-avx2.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx2 /cvm
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true

--- a/python/pip-avx512-gentoo.conf
+++ b/python/pip-avx512-gentoo.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true

--- a/python/pip-avx512.conf
+++ b/python/pip-avx512.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true

--- a/python/pip-generic-gentoo.conf
+++ b/python/pip-generic-gentoo.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true

--- a/python/pip-gentoo.conf
+++ b/python/pip-gentoo.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true

--- a/python/pip-sse3-gentoo.conf
+++ b/python/pip-sse3-gentoo.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true

--- a/python/pip.conf
+++ b/python/pip.conf
@@ -6,12 +6,10 @@ find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/sse3 /cvm
 
 [wheel]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 disable-pip-version-check = true
 
 [install]
 find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/nix/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-use-wheel = true
 constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
 only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
 prefer-binary = true


### PR DESCRIPTION
Remove deprecated `--use-wheel` config option. [Pip v10.0.0b1 (2018-03-31)](https://github.com/pypa/pip/blob/main/NEWS.rst#1000b1-2018-03-31) : Removed the deprecated --(no-)use-wheel flags to pip install and pip wheel. ([#2699](https://github.com/pypa/pip/pull/2699))


