### PR TITLE
switch RSNT_ENABLE_LMOD_CACHE to auto by default

### DIFF
--- a/profile.d/z-20-lmod.csh
+++ b/profile.d/z-20-lmod.csh
@@ -8,7 +8,7 @@ setenv LMOD_RC $LMOD_PACKAGE_PATH/lmodrc.lua
 setenv LMOD_SHORT_TIME 3600
 
 if ( ! $?RSNT_ENABLE_LMOD_CACHE ) then
-	setenv RSNT_ENABLE_LMOD_CACHE "yes"
+	setenv RSNT_ENABLE_LMOD_CACHE "auto"
 endif
 
 if ( ! $?__Init_Default_Modules ) then

--- a/profile.d/z-20-lmod.sh
+++ b/profile.d/z-20-lmod.sh
@@ -7,7 +7,7 @@ export LMOD_AVAIL_EXTENSIONS=no
 export LMOD_RC=$LMOD_PACKAGE_PATH/lmodrc.lua
 export LMOD_SHORT_TIME=3600
 if [[ -z "$RSNT_ENABLE_LMOD_CACHE" ]]; then
-	export RSNT_ENABLE_LMOD_CACHE="yes"
+	export RSNT_ENABLE_LMOD_CACHE="auto"
 fi
 if [[ -z "$__Init_Default_Modules" ]]; then
 	NEWMODULERCFILE=$LMOD_PACKAGE_PATH/modulerc


### PR DESCRIPTION
This is using
https://github.com/ComputeCanada/software-stack-custom/pull/37

to fix 
https://github.com/ComputeCanada/software-stack/issues/110

On `build-node`, we need to locally set `RSNT_ENABLE_LMOD_CACHE=yes` to always enable the Lmod cache.