### PR TITLE
Disable the new ofi (libfabric) btl on omnipath/ethernet in Open MPI

### DIFF
--- a/lmod/openmpi_custom.lua
+++ b/lmod/openmpi_custom.lua
@@ -97,6 +97,8 @@ elseif  ompiv == "3.1" or ompiv == "4.0" or ompiv == "4.1" then
 	        if ompiv == "3.1" then -- removed in 4.0; don't use ofi by default for cuda
 			setenv("OMPI_MCA_mtl", "^mxm,ofi")
 			setenv("OMPI_MCA_oob", "^ud")
+		elseif ompiv == "4.1" -- omnipath nodes may run out of contexts if the ofi btl is enabled
+			setenv("OMPI_MCA_btl", "^openib,ofi")
 		end
 	        setenv("OMPI_MCA_coll", "^fca,hcoll")
 		setenv("OMPI_MCA_osc", "^ucx")


### PR DESCRIPTION
This btl speeds up one-sided communication (MPI_Put, MPI_Get, and co)
but allocates a second separate hardware context per process
on omnipath.

So for instance, on 48-core Cedar nodes, once you use more than 24
MPI processes you run out of contexts (2x25=50 > 48 available contexts)

See
https://github.com/open-mpi/ompi/issues/9575

An alternative for Cedar would be to set
num_user_contexts=96 in /etc/modprobe.d/hfi1.conf
(in general, 2x the number of cores per node)
if that happens, we may be able to revert this change.