### PR TITLE
switched back to cache being automatically enabled

### DIFF
--- a/profile.d/z-20-lmod.csh
+++ b/profile.d/z-20-lmod.csh
@@ -8,7 +8,7 @@ setenv LMOD_RC $LMOD_PACKAGE_PATH/lmodrc.lua
 setenv LMOD_SHORT_TIME 3600
 
 if ( ! $?RSNT_ENABLE_LMOD_CACHE ) then
-	setenv RSNT_ENABLE_LMOD_CACHE "auto"
+	setenv RSNT_ENABLE_LMOD_CACHE "yes"
 endif
 
 if ( ! $?__Init_Default_Modules ) then

--- a/profile.d/z-20-lmod.sh
+++ b/profile.d/z-20-lmod.sh
@@ -7,7 +7,7 @@ export LMOD_AVAIL_EXTENSIONS=no
 export LMOD_RC=$LMOD_PACKAGE_PATH/lmodrc.lua
 export LMOD_SHORT_TIME=3600
 if [[ -z "$RSNT_ENABLE_LMOD_CACHE" ]]; then
-	export RSNT_ENABLE_LMOD_CACHE="auto"
+	export RSNT_ENABLE_LMOD_CACHE="yes"
 fi
 if [[ -z "$__Init_Default_Modules" ]]; then
 	NEWMODULERCFILE=$LMOD_PACKAGE_PATH/modulerc


### PR DESCRIPTION
Lmod 8.7.4 has been deployed. 
You can test that cache is working correctly using: 

```
export RSNT_ENABLE_LMOD_CACHE="yes"
module --force purge
module load StdEnv/2020
``` 

