### PR TITLE
Improve readability of CUDA compatibility driver testing

### DIFF
--- a/lmod/SitePackage.lua
+++ b/lmod/SitePackage.lua
@@ -256,7 +256,7 @@ function cuda_driver_library_available(cuda_version_two_digits)
 	if (restricted_available == "true") then
 		-- Older compat versions need driver 418.40.04+, 11.7 needs 450.36.06+, see
 		-- https://docs.nvidia.com/deploy/cuda-compatibility/index.html#use-the-right-compat-package
-		if convertToCanonical(cuda_version_two_digits) >= convertToCanonical("11.7")
+		if convertToCanonical(cuda_version_two_digits) >= convertToCanonical("11.7") then
 		    if convertToCanonical(driver_version) >= convertToCanonical("450.36.06") then
 			return "compat"
 		    end

--- a/lmod/SitePackage.lua
+++ b/lmod/SitePackage.lua
@@ -251,16 +251,16 @@ function cuda_driver_library_available(cuda_version_two_digits)
 		return "native"
 	end
 
-	-- Older compat versions need driver 418.40.04+, 11.7 needs 450.36.06+, see
-	-- https://docs.nvidia.com/deploy/cuda-compatibility/index.html#use-the-right-compat-package
-	if convertToCanonical(driver_version) >= convertToCanonical("418.40.04") then
-		if (convertToCanonical(driver_version) >= convertToCanonical("450.36.06") or
-		    convertToCanonical(cuda_version_two_digits) < convertToCanonical("11.7")) then
-			local restricted_available = os.getenv("CC_RESTRICTED") or "false"
-			if (restricted_available == "true") then
-				-- can use compat library via LD_LIBRARY_PATH
-				return "compat"
-			end
+	-- can possibly use compat library via LD_LIBRARY_PATH
+	local restricted_available = os.getenv("CC_RESTRICTED") or "false"
+	if (restricted_available == "true") then
+		-- Older compat versions need driver 418.40.04+, 11.7 needs 450.36.06+, see
+		-- https://docs.nvidia.com/deploy/cuda-compatibility/index.html#use-the-right-compat-package
+		if (convertToCanonical(cuda_version_two_digits) >= convertToCanonical("11.7") and
+		    convertToCanonical(driver_version) >= convertToCanonical("450.36.06")) then
+			return "compat"
+		elseif convertToCanonical(driver_version) >= convertToCanonical("418.40.04") then
+			return "compat"
 		end
 	end
 	return "none"

--- a/lmod/SitePackage.lua
+++ b/lmod/SitePackage.lua
@@ -256,9 +256,10 @@ function cuda_driver_library_available(cuda_version_two_digits)
 	if (restricted_available == "true") then
 		-- Older compat versions need driver 418.40.04+, 11.7 needs 450.36.06+, see
 		-- https://docs.nvidia.com/deploy/cuda-compatibility/index.html#use-the-right-compat-package
-		if (convertToCanonical(cuda_version_two_digits) >= convertToCanonical("11.7") and
-		    convertToCanonical(driver_version) >= convertToCanonical("450.36.06")) then
+		if convertToCanonical(cuda_version_two_digits) >= convertToCanonical("11.7")
+		    if convertToCanonical(driver_version) >= convertToCanonical("450.36.06") then
 			return "compat"
+		    end
 		elseif convertToCanonical(driver_version) >= convertToCanonical("418.40.04") then
 			return "compat"
 		end


### PR DESCRIPTION
The logic seems more readable to me written this way.

Note: I did not actually test this.