### PR TITLE
Hide singularity and apptainer-1.0

### DIFF
--- a/lmod/SitePackage_visible.lua
+++ b/lmod/SitePackage_visible.lua
@@ -27,17 +27,6 @@ function visible_hook(t)
 	local pathT = {
 		[ "vasp" ] = "/opt/software/easybuild",
 		[ "gaussian" ] = "/opt/software/gaussian",
-		[ "singularity/2.5" ] = "/opt/software/singularity-2.5",
-		[ "singularity/2.6" ] = "/opt/software/singularity-2.6",
-		[ "singularity/3.1" ] = "/opt/software/singularity-3.1",
-		[ "singularity/3.2" ] = "/opt/software/singularity-3.2",
-		[ "singularity/3.3" ] = "/opt/software/singularity-3.3",
-		[ "singularity/3.4" ] = "/opt/software/singularity-3.4",
-		[ "singularity/3.5" ] = "/opt/software/singularity-3.5-hidden",
-		[ "singularity/3.6" ] = "/opt/software/singularity-3.6-hidden",
-		[ "singularity/3.7" ] = "/opt/software/singularity-3.7-hidden",
-                [ "singularity/3.8" ] = "/opt/software/singularity-3.8-hidden",
-                [ "apptainer/1.0" ] = "/opt/software/apptainer-1.0-hidden",
                 [ "apptainer-suid/1.1" ] = "/opt/software/apptainer-1.1",
 	}
 	local moduleName = t.sn

--- a/lmod/SitePackage_visible.lua
+++ b/lmod/SitePackage_visible.lua
@@ -35,8 +35,10 @@ function visible_hook(t)
 		[ "singularity/3.4" ] = "/opt/software/singularity-3.4",
 		[ "singularity/3.5" ] = "/opt/software/singularity-3.5-hidden",
 		[ "singularity/3.6" ] = "/opt/software/singularity-3.6-hidden",
-		[ "singularity/3.7" ] = "/opt/software/singularity-3.7",
-                [ "singularity/3.8" ] = "/opt/software/singularity-3.8",
+		[ "singularity/3.7" ] = "/opt/software/singularity-3.7-hidden",
+                [ "singularity/3.8" ] = "/opt/software/singularity-3.8-hidden",
+                [ "apptainer/1.0" ] = "/opt/software/apptainer-1.0-hidden",
+                [ "apptainer-suid/1.1" ] = "/opt/software/apptainer-1.1",
 	}
 	local moduleName = t.sn
 	local fullName = t.fullName

--- a/lmod/modulerc
+++ b/lmod/modulerc
@@ -62,9 +62,9 @@ hide-version python27-mpi4py/2.0.0
 hide-version python35-mpi4py/2.0.0
 hide-version caffe2/0.8.1
 hide-version librt-compat/centos7
-hide-version singularity/2.3
-hide-version singularity/2.4
-hide-version singularity/3.1
+hide-version singularity/3.7
+hide-version singularity/3.8
+hide-version apptainer/1.0
 hide-version gentoo/2019
 hide-version julia/0.5.1
 hide-version julia/0.6.0


### PR DESCRIPTION
Hide all versions of singularity, and the suid apptainer 1.0 because of security concerns.

apptainer-suid/1.1 is automatically hidden if not installed on a cluster now.