### PR TITLE
Deprecate and hide rstudio-server/2021.09.1+372

### DIFF
--- a/lmod/admin.list
+++ b/lmod/admin.list
@@ -46,3 +46,7 @@ This version of Julia was compiled with the Intel compiler, which is not recomme
 	module load gcc/7.3.0 julia
 Cette version de Julia a été compilée avec les compilateurs Intel, ce qui n'est pas recommandé par les développeurs de Julia. Nous vous suggérons de plutôt charger la version compilée avec le compilateur gcc/7.3.0 : 
 	module load gcc/7.3.0 julia
+
+rstudio-server/2021.09.1+372:
+This module is deprecated and will be removed in the future. Please use the module "rstudio-server/4.1" instead.
+Ce module est obsolète et sera supprimé dans le futur. Veuillez utiliser le module "rstudio-server/4.1" plutôt.

--- a/lmod/modulerc
+++ b/lmod/modulerc
@@ -71,6 +71,7 @@ hide-version julia/0.6.0
 hide-version julia/0.6.2
 hide-version julia/1.0.0
 hide-version impi/2018.3.222
+hide-version rstudio-server/2021.09.1+372
 #hide-version cuda/10.0.130
 # default versions for hidden deprecated modules,
 # where there is only one version per directory


### PR DESCRIPTION
Deprecate in favor of `rstudio-server/4.1` with a matching R module.

Must be pushed with the module : `rstudio-server/4.1`