### PR TITLE
renamed and adjusted gentoo pip config files for gentoo2020, leaving …

### DIFF
--- a/python/pip-avx-gentoo.conf
+++ b/python/pip-avx-gentoo.conf
@@ -1,17 +1,1 @@
-[global]
-disable-pip-version-check = true
-
-[download]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-
-[wheel]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-disable-pip-version-check = true
-
-[install]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
-only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
-prefer-binary = true
-disable-pip-version-check = true
-
+pip-avx-gentoo2020.conf

--- a/python/pip-avx-gentoo2020.conf
+++ b/python/pip-avx-gentoo2020.conf
@@ -1,0 +1,17 @@
+[global]
+disable-pip-version-check = true
+
+[download]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+
+[wheel]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+disable-pip-version-check = true
+
+[install]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
+only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
+prefer-binary = true
+disable-pip-version-check = true
+

--- a/python/pip-avx2-gentoo.conf
+++ b/python/pip-avx2-gentoo.conf
@@ -1,17 +1,1 @@
-[global]
-disable-pip-version-check = true
-
-[download]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-
-[wheel]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-disable-pip-version-check = true
-
-[install]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
-only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
-prefer-binary = true
-disable-pip-version-check = true
-
+pip-avx2-gentoo2020.conf

--- a/python/pip-avx2-gentoo2020.conf
+++ b/python/pip-avx2-gentoo2020.conf
@@ -1,0 +1,17 @@
+[global]
+disable-pip-version-check = true
+
+[download]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+
+[wheel]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+disable-pip-version-check = true
+
+[install]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
+only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
+prefer-binary = true
+disable-pip-version-check = true
+

--- a/python/pip-avx512-gentoo.conf
+++ b/python/pip-avx512-gentoo.conf
@@ -1,17 +1,1 @@
-[global]
-disable-pip-version-check = true
-
-[download]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-
-[wheel]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-disable-pip-version-check = true
-
-[install]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
-only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
-prefer-binary = true
-disable-pip-version-check = true
-
+pip-avx512-gentoo2020.conf

--- a/python/pip-avx512-gentoo2020.conf
+++ b/python/pip-avx512-gentoo2020.conf
@@ -1,0 +1,17 @@
+[global]
+disable-pip-version-check = true
+
+[download]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+
+[wheel]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+disable-pip-version-check = true
+
+[install]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx512 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/avx2 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
+only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
+prefer-binary = true
+disable-pip-version-check = true
+

--- a/python/pip-generic-gentoo.conf
+++ b/python/pip-generic-gentoo.conf
@@ -1,17 +1,1 @@
-[global]
-disable-pip-version-check = true
-
-[download]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-
-[wheel]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-disable-pip-version-check = true
-
-[install]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
-only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
-prefer-binary = true
-disable-pip-version-check = true
-
+pip-generic-gentoo2020.conf

--- a/python/pip-generic-gentoo2020.conf
+++ b/python/pip-generic-gentoo2020.conf
@@ -1,0 +1,17 @@
+[global]
+disable-pip-version-check = true
+
+[download]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+
+[wheel]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+disable-pip-version-check = true
+
+[install]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
+only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
+prefer-binary = true
+disable-pip-version-check = true
+

--- a/python/pip-sse3-gentoo.conf
+++ b/python/pip-sse3-gentoo.conf
@@ -1,17 +1,1 @@
-[global]
-disable-pip-version-check = true
-
-[download]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-
-[wheel]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-disable-pip-version-check = true
-
-[install]
-find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
-constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
-only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
-prefer-binary = true
-disable-pip-version-check = true
-
+pip-sse3-gentoo2020.conf

--- a/python/pip-sse3-gentoo2020.conf
+++ b/python/pip-sse3-gentoo2020.conf
@@ -1,0 +1,17 @@
+[global]
+disable-pip-version-check = true
+
+[download]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+
+[wheel]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+disable-pip-version-check = true
+
+[install]
+find-links = /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/sse3 /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo2020/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/gentoo/generic /cvmfs/soft.computecanada.ca/custom/python/wheelhouse/generic
+constraint = /cvmfs/soft.computecanada.ca/config/python/constraints.txt
+only-binary = numpy,scipy,mpi4py,pandas,h5py,Cython,grpcio
+prefer-binary = true
+disable-pip-version-check = true
+


### PR DESCRIPTION
…symlinks behind

This cherry-picks the first commit of #57 so that `gentoo2020` is supported by our current python modules now that https://github.com/ComputeCanada/wheels_builder/pull/92 has been merged