### PR TITLE
Added cmake constraint. Force our dummy wheel or fail for version above.

### DIFF
--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -1,1 +1,2 @@
 pip <= 18.1; python_version < '3'
+cmake==3.23.1+dummy.computecanada # Force our dummy wheel or fail for version above


### PR DESCRIPTION
CMake Python wheel are duplicate of the system cmake, in order for python packages to build with cmake, it provides `cmake`, `cpack` and `ctest` binaries
Having cmake wheels are unnecessary and takes a very long time to build, and fails randomly sometimes

Having a dummy wheel where we constraint pip to install our dummy wheel (`3.23.1`) or fail if a version above our module is requested.

Meet the requirements : `cmake`, `cmake<3.24`, `cmake>3.21`
Fails when : 
- version is lower, ie `cmake==3.22`. We then need to sed the build requirement this is not often
- version is above ie `cmake>3.27`. Means we need to install that version has some specific features might be used.