### PR TITLE
Add deprecation message for StdEnv/2016.4 and StdEnv/2018.3, change the global default to StdEnv/2020

### DIFF
--- a/lmod/admin.list
+++ b/lmod/admin.list
@@ -50,3 +50,11 @@ Cette version de Julia a été compilée avec les compilateurs Intel, ce qui n'e
 rstudio-server/2021.09.1+372:
 This module is deprecated and will be removed in the future. Please use the module "rstudio-server/4.1" instead.
 Ce module est obsolète et sera supprimé dans le futur. Veuillez utiliser le module "rstudio-server/4.1" plutôt.
+
+StdEnv/2016.4 | StdEnv/2018.3:
+These standard environment modules are deprecated and now contain software packages that have security issues. We recommend not using these, and
+instead use our more recent StdEnv modules. Use at your own risk. 
+
+Ces modules d'environnements logiciels standards sont marqués pour être retirés et contiennent des logiciels qui ont des problèmes de sécurité.
+Nous recommandons de cesser de les utiliser et de préférer nos modules StdEnv plus récents. Utilisez à votre propre risque.
+

--- a/lmod/modulerc
+++ b/lmod/modulerc
@@ -1,35 +1,7 @@
 #%Module
 
 # default versions
-module-version StdEnv/2016.4 default
-module-version boost/1.60.0 default
-module-version boost-mpi/1.60.0 default
-module-version imkl/11.3.4.258 default
-module-version intel/2016.4 default
-module-version openmpi/2.1.1 default
-module-version gcc/5.4.0 default
-module-version cuda/8.0.44 default
-module-version python/3.7.4 default
-module-version singularity/3.8 default
-module-version matlab/2018b default
-module-version scipy-stack/2019a default
-
-# shortcut versions
-#module-version intel/2018.3 2018 18
-#module-version intel/2017.5 2017 17
-#module-version intel/2016.4 2016 16
-#module-version python/2.7.14 2.7 2
-#module-version python/3.5.4 3.5
-#module-version python/3.6.3 3.6 
-#module-version python/3.7.4 3.7 3
-#module-version python/3.8.0 3.8
-#module-version r/3.3.3 3.3 3
-#module-version imkl/11.3.4.258 11
-#module-version imkl/2017.4.239 2017.4 2017
-#module-version imkl/2018.3.222 2018.3 2018
-#module-version cuda/8.0.44 8.0 8
-#module-version cuda/9.0.176 9.0 9
-#module-version cuda/10.0.130 10.0 10
+module-version StdEnv/2020 default
 
 # module aliases (uses symlinks)
 hide-version allinea-cpu/7.1

--- a/lmod/modulerc
+++ b/lmod/modulerc
@@ -22,34 +22,8 @@ hide-version arm-forge-gpu/19.1.4
 hide-version arm-forge-gpu/20.2
 
 # hidden versions
-hide-version parallel/20170622
-hide-version parallel/20160722
-hide-version boost/1.63.0
-hide-version flex/2.5.39
-hide-version python/3.5.2
-hide-version python/2.7.13
-hide-version python27-scipy-stack/2017a
-hide-version python35-scipy-stack/2017a
-hide-version python27-mpi4py/2.0.0
-hide-version python35-mpi4py/2.0.0
-hide-version caffe2/0.8.1
 hide-version librt-compat/centos7
 hide-version singularity/3.7
 hide-version singularity/3.8
 hide-version apptainer/1.0
-hide-version gentoo/2019
-hide-version julia/0.5.1
-hide-version julia/0.6.0
-hide-version julia/0.6.2
-hide-version julia/1.0.0
-hide-version impi/2018.3.222
 hide-version rstudio-server/2021.09.1+372
-#hide-version cuda/10.0.130
-# default versions for hidden deprecated modules,
-# where there is only one version per directory
-module-version python27-scipy-stack/2017a default
-module-version python35-scipy-stack/2017a default
-module-version python27-mpi4py/2.0.0 default
-module-version python35-mpi4py/2.0.0 default
-module-version caffe2/0.8.1 default
-

--- a/lmod/modulerc_2016_2018
+++ b/lmod/modulerc_2016_2018
@@ -1,0 +1,66 @@
+#%Module
+
+# default versions
+module-version StdEnv/2016.4 default
+module-version boost/1.60.0 default
+module-version boost-mpi/1.60.0 default
+module-version imkl/11.3.4.258 default
+module-version intel/2016.4 default
+module-version openmpi/2.1.1 default
+module-version gcc/5.4.0 default
+module-version cuda/8.0.44 default
+module-version python/3.7.4 default
+module-version singularity/3.8 default
+module-version matlab/2018b default
+module-version scipy-stack/2019a default
+
+# module aliases (uses symlinks)
+hide-version allinea-cpu/7.1
+hide-version allinea-cpu/18.3
+hide-version allinea-cpu/19.1.4
+hide-version allinea-cpu/20.2
+hide-version allinea-gpu/7.1
+hide-version allinea-gpu/18.3
+hide-version allinea-gpu/19.1.4
+hide-version allinea-gpu/20.2
+hide-version arm-forge-cpu/7.1
+hide-version arm-forge-cpu/18.3
+hide-version arm-forge-cpu/19.1.4
+hide-version arm-forge-cpu/20.2
+hide-version arm-forge-gpu/7.1
+hide-version arm-forge-gpu/18.3
+hide-version arm-forge-gpu/19.1.4
+hide-version arm-forge-gpu/20.2
+
+# hidden versions
+hide-version parallel/20170622
+hide-version parallel/20160722
+hide-version boost/1.63.0
+hide-version flex/2.5.39
+hide-version python/3.5.2
+hide-version python/2.7.13
+hide-version python27-scipy-stack/2017a
+hide-version python35-scipy-stack/2017a
+hide-version python27-mpi4py/2.0.0
+hide-version python35-mpi4py/2.0.0
+hide-version caffe2/0.8.1
+hide-version librt-compat/centos7
+hide-version singularity/3.7
+hide-version singularity/3.8
+hide-version apptainer/1.0
+hide-version gentoo/2019
+hide-version julia/0.5.1
+hide-version julia/0.6.0
+hide-version julia/0.6.2
+hide-version julia/1.0.0
+hide-version impi/2018.3.222
+hide-version rstudio-server/2021.09.1+372
+#hide-version cuda/10.0.130
+# default versions for hidden deprecated modules,
+# where there is only one version per directory
+module-version python27-scipy-stack/2017a default
+module-version python35-scipy-stack/2017a default
+module-version python27-mpi4py/2.0.0 default
+module-version python35-mpi4py/2.0.0 default
+module-version caffe2/0.8.1 default
+


### PR DESCRIPTION
This would address 
https://github.com/ComputeCanada/software-stack/issues/132
partly. It deprecates, but does not hide (yet). 