### PR TITLE
Deprecate busco module as it causes issues and confusion for users

### DIFF
--- a/lmod/admin.list
+++ b/lmod/admin.list
@@ -50,3 +50,8 @@ Cette version de Julia a été compilée avec les compilateurs Intel, ce qui n'e
 rstudio-server/2021.09.1+372:
 This module is deprecated and will be removed in the future. Please use the module "rstudio-server/4.1" instead.
 Ce module est obsolète et sera supprimé dans le futur. Veuillez utiliser le module "rstudio-server/4.1" plutôt.
+
+busco/5.0.0 | busco/5.2.2:
+This module is deprecated and will be removed in the future. Please use the Python wheel instead.
+Ce module est obsolète et sera supprimé dans le futur. Veuillez utiliser le wheel Python plutôt.
+For more information | Pour plus d'information : https://docs.alliancecan.ca/wiki/BUSCO#Installation

--- a/lmod/modulerc
+++ b/lmod/modulerc
@@ -72,6 +72,8 @@ hide-version julia/0.6.2
 hide-version julia/1.0.0
 hide-version impi/2018.3.222
 hide-version rstudio-server/2021.09.1+372
+hide-version busco/5.0.0
+hide-version busco/5.2.2
 #hide-version cuda/10.0.130
 # default versions for hidden deprecated modules,
 # where there is only one version per directory
@@ -80,4 +82,3 @@ module-version python35-scipy-stack/2017a default
 module-version python27-mpi4py/2.0.0 default
 module-version python35-mpi4py/2.0.0 default
 module-version caffe2/0.8.1 default
-


### PR DESCRIPTION
Users should use the Python wheel and follow : https://docs.alliancecan.ca/wiki/BUSCO#Installation