### PR TITLE
Remove outdated Python warning for 3.10.

### DIFF
--- a/lmod/SitePackage.lua
+++ b/lmod/SitePackage.lua
@@ -373,21 +373,6 @@ https://docs.computecanada.ca/wiki/Standard_software_environments]])
 		--color_banner("red")
 	end
 	
-	-- only show the warning if the user provided a shortened version of python as load, if the defaultKind is system or marked, and if it does not result in 3.10.2
-	if (userProvidedName == "python" or userProvidedName == "python/3" or userProvidedName == "python/3.") then
-		if (moduleVersion ~= "3.10.2" and (defaultKind == "system" or defaultKind == "unknown" or defaultKind == "marked")) then
-			if (string.sub(lang,1,2) == "fr") then
-				LmodWarning([[Attention, le 4 avril 2023, la version par défaut de python deviendra 3.10. 
-Pour continuer d'utiliser la version 3.8, veuillez charger le module python/3.8 explicitement.
-]])
-			else
-				LmodWarning([[Warning. On April 4th 2023, the default version of python will become 3.10. 
-To keep using python 3.8, please load the python/3.8 module explicitly. 
-]])
-			end
-		end
-		--color_banner("red")
-	end
 end
 local function unload_hook(t)
 	set_family(t)


### PR DESCRIPTION
This message now triggers for "module load python" in StdEnv/2023... Fixes https://github.com/ComputeCanada/software-stack/issues/136