### PR TITLE
adjust warning for new StdEnv/2023, but disable it by default

### DIFF
--- a/lmod/SitePackage.lua
+++ b/lmod/SitePackage.lua
@@ -310,22 +310,23 @@ with AMD processors. Please instead use the StdEnv/2020 standard environment and
 	end
 end
 local function default_module_change_warning(t)
+	return -- temporarily disable warning message
 	local moduleName = myModuleName()
 
 	-- only go further for StdEnv
 	if (moduleName ~= "StdEnv" and moduleName ~= "python") then return end
 	-- allow to completely disable the upcoming transition
-	local enableStdEnv2020Transition = os.getenv("RSNT_ENABLE_STDENV2020_TRANSITION") or "unknown"
-	if (enableStdEnv2020Transition == "unknown") then
+	local enableStdEnv2023Transition = os.getenv("RSNT_ENABLE_STDENV2023_TRANSITION") or "unknown"
+	if (enableStdEnv2023Transition == "unknown") then
 		-- Niagara sets the variable locally
    		local cccluster = os.getenv("CC_CLUSTER") or "computecanada"
-		if (cccluster == "cedar" or cccluster == "graham" or cccluster == "beluga") then
-			enableStdEnv2020Transition = "yes"
+		if (cccluster == "cedar" or cccluster == "graham" or cccluster == "beluga" or cccluster == "narval") then
+			enableStdEnv2023Transition = "yes"
 		else
-			enableStdEnv2020Transition = "no"
+			enableStdEnv2023Transition = "no"
 		end
 	end
-	if (enableStdEnv2020Transition == "no") then return end
+	if (enableStdEnv2023Transition == "no") then return end
 
 	local FrameStk   = require("FrameStk")
 	local frameStk   = FrameStk:singleton()
@@ -345,27 +346,27 @@ local function default_module_change_warning(t)
    	local lang = os.getenv("LANG") or "en"
 
 	-- only show the warning if the user provided "StdEnv" as load, if the defaultKind is system, and if it does not result in 2020
-	if (userProvidedName == "StdEnv" and moduleVersion ~= "2020" and (defaultKind == "system" or defaultKind == "unknown")) then
+	if (userProvidedName == "StdEnv" and moduleVersion ~= "2023" and (defaultKind == "system" or defaultKind == "unknown")) then
 		--color_banner("red")
 		if (string.sub(lang,1,2) == "fr") then
-			LmodWarning([[Attention, le 1er avril 2021, la version par défaut de l'environnement standard sera mise à jour.
+			LmodWarning([[Attention, le 1er avril 2024, la version par défaut de l'environnement standard sera mise à jour.
 Pour tester vos tâches avec le nouvel environnement, exécutez la commande :
-module load StdEnv/2020
+module load StdEnv/2023
 
 Pour changer votre version par défaut immédiatement, exécutez la commande suivante : 
 
-echo "module-version StdEnv/2020 default" >> $HOME/.modulerc
+echo "module-version StdEnv/2023 default" >> $HOME/.modulerc
 
 Pour davantage d'information, visitez :
 https://docs.computecanada.ca/wiki/Standard_software_environments/fr]])
 		else
-			LmodWarning([[Warning, April 1st 2021, the default standard environment module will be changed to a more recent one.
+			LmodWarning([[Warning, April 1st 2024, the default standard environment module will be changed to a more recent one.
 To test your jobs with the new environment, please run:
-module load StdEnv/2020
+module load StdEnv/2023
 
 To change your default version immediately, please run the following command:
 
-echo "module-version StdEnv/2020 default" >> $HOME/.modulerc
+echo "module-version StdEnv/2023 default" >> $HOME/.modulerc
 
 For more information, please see:
 https://docs.computecanada.ca/wiki/Standard_software_environments]])


### PR DESCRIPTION
When we are ready to display the warning, we just need to remove the initial return