### PR TITLE
Add configuration file to set APPTAINER_BIND for Apptainer `/scratch` and `/project`

### DIFF
--- a/lmod/apptainer_custom.lua
+++ b/lmod/apptainer_custom.lua
@@ -1,0 +1,33 @@
+local posix = require "posix"
+local io = require "io"
+local bindmounts = ""
+for i, dir in ipairs({"/project", "/scratch"}) do
+   dirtype = posix.stat(dir, "type")
+   if dirtype == 'link' or dirtype == 'directory' then
+      local root = dir
+      if dirtype == 'link' then
+         -- Niagara, symlink
+         root = posix.readlink(dir)
+      else
+         for line in io.lines("/proc/self/mountinfo") do
+            match = line:match(" " .. dir .. " " .. dir .. " %S+ %S+ %S+ %S+ [^/]+(%S+) ")
+            if match ~= nil then
+               -- Beluga/Narval
+               root = match .. dir
+            end
+         end
+      end
+      if bindmounts ~= "" then
+         bindmounts = bindmounts .. ","
+      end
+      if root == dir then
+         bindmounts = bindmounts .. dir
+      else
+         bindmounts = bindmounts .. root .. "," .. root .. ":" .. dir
+      end
+   end
+end
+
+if bindmounts ~= "" then
+   setenv("APPTAINER_BIND", bindmounts)
+end


### PR DESCRIPTION
There are 4 possibilities
a) neither /project nor /scratch are present
b) they are direct mount points (Cedar/Graham)
c) they are symlinks (Niagara)
d) they are bindmounts (Beluga/Narval)

This will set e.g.
`APPTAINER_BIND=/lustre06/project,/lustre06/project:/project,/lustre07/scratch,/lustre07/scratch:/scratch` on Narval

See https://github.com/ComputeCanada/software-stack/issues/126