### PR TITLE
fix: add `/localscratch` to `APPTAINER_BIND`

### DIFF
--- a/lmod/apptainer_custom.lua
+++ b/lmod/apptainer_custom.lua
@@ -1,7 +1,7 @@
 local posix = require "posix"
 local io = require "io"
 local bindmounts = ""
-for i, dir in ipairs({"/project", "/scratch"}) do
+for i, dir in ipairs({"/project", "/scratch", "/localscratch"}) do
    dirtype = posix.stat(dir, "type")
    if dirtype == 'link' or dirtype == 'directory' then
       local root = dir


### PR DESCRIPTION
We have been encountering issues with `/localscratch` (i.e. `$SLURM_TMPDIR`) not getting mounted on startup of jobs that are landing on `cedar` from OSG htcondor. Because htcondor's `+SingularityImage` causes the job to immediately start a container, we don't have a way to inject `APPTAINER_BIND` modifications.

This PR adds `/localscratch` to the paths that are injected in `APPTAINER_BIND` for bind mounting.