### PR TITLE
Avoid resetting LMOD_RC if we don't reload initial modules

### DIFF
--- a/profile.d/z-20-lmod.csh
+++ b/profile.d/z-20-lmod.csh
@@ -4,7 +4,6 @@ setenv LMOD_PACKAGE_PATH /cvmfs/soft.computecanada.ca/config/lmod/
 setenv LMOD_ADMIN_FILE /cvmfs/soft.computecanada.ca/config/lmod/admin.list
 setenv LMOD_AVAIL_STYLE grouped:system
 setenv LMOD_AVAIL_EXTENSIONS no
-setenv LMOD_RC $LMOD_PACKAGE_PATH/lmodrc.lua
 setenv LMOD_SHORT_TIME 3600
 
 if ( ! $?RSNT_ENABLE_LMOD_CACHE ) then
@@ -12,6 +11,7 @@ if ( ! $?RSNT_ENABLE_LMOD_CACHE ) then
 endif
 
 if ( ! $?__Init_Default_Modules ) then
+	setenv LMOD_RC $LMOD_PACKAGE_PATH/lmodrc.lua
 	set NEWMODULERCFILE=${LMOD_PACKAGE_PATH}/modulerc
 	if ( $?CC_CLUSTER && -f ${LMOD_PACKAGE_PATH}/modulerc_${CC_CLUSTER} ) then
 		set NEWMODULERCFILE=${LMOD_PACKAGE_PATH}/modulerc_${CC_CLUSTER}:${NEWMODULERCFILE}

--- a/profile.d/z-20-lmod.sh
+++ b/profile.d/z-20-lmod.sh
@@ -4,12 +4,12 @@ export LMOD_PACKAGE_PATH=/cvmfs/soft.computecanada.ca/config/lmod/
 export LMOD_ADMIN_FILE=/cvmfs/soft.computecanada.ca/config/lmod/admin.list
 export LMOD_AVAIL_STYLE=grouped:system
 export LMOD_AVAIL_EXTENSIONS=no
-export LMOD_RC=$LMOD_PACKAGE_PATH/lmodrc.lua
 export LMOD_SHORT_TIME=3600
 if [[ -z "$RSNT_ENABLE_LMOD_CACHE" ]]; then
 	export RSNT_ENABLE_LMOD_CACHE="yes"
 fi
 if [[ -z "$__Init_Default_Modules" ]]; then
+	export LMOD_RC=$LMOD_PACKAGE_PATH/lmodrc.lua
 	NEWMODULERCFILE=$LMOD_PACKAGE_PATH/modulerc
 	if [[ ! -z "$CC_CLUSTER" && -f $LMOD_PACKAGE_PATH/modulerc_${CC_CLUSTER} ]]; then
 		NEWMODULERCFILE=$LMOD_PACKAGE_PATH/modulerc_${CC_CLUSTER}:$NEWMODULERCFILE


### PR DESCRIPTION
move the reset of LMOD_RC in the block that loads initial modules to avoid resetting LMOD_RC during jobs, for issue [#88](https://github.com/ComputeCanada/software-stack-config/issues/88) 