### PR TITLE
Disable registrations of loaded_modules, serializeTbl and clearWarningFlag

### DIFF
--- a/lmod/SitePackage.lua
+++ b/lmod/SitePackage.lua
@@ -120,7 +120,9 @@ dofile(pathJoin(lmod_package_path,"SitePackage_properties.lua"))
 dofile(pathJoin(lmod_package_path,"SitePackage_visible.lua"))
 dofile(pathJoin(lmod_package_path,"SitePackage_localpaths.lua"))
 
-sandbox_registration{ loadfile = loadfile, assert = assert, loaded_modules = loaded_modules, serializeTbl = serializeTbl, clearWarningFlag = clearWarningFlag  }
+sandbox_registration{ loadfile = loadfile, assert = assert }
+-- sandbox_registration { serializeTbl = serializeTbl } only used in commented out code in SitePackage_logging.lua
+
 require("strict")
 require("string_utils")
 local hook      = require("Hook")


### PR DESCRIPTION
`loaded_modules` was used in the past for arch modules but any more.
`serializeTbl` is only used in commented out warnings in `SitePackage_logging.lua`.
`clearWarningFlag` isn't used anywhere and removed in newer Lmod such as 8.7.46.