### PR TITLE
Also hide gentoo/2020 on new clusters.

### DIFF
--- a/lmod/modulerc_tamia
+++ b/lmod/modulerc_tamia
@@ -1,3 +1,4 @@
 hide-version StdEnv/2020
+hide-version gentoo/2020
 module-version cuda/12.6 default
 


### PR DESCRIPTION
Otherwise it still shows up in module avail