### PR TITLE
Add agent context files for alliance clusters

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -4,15 +4,18 @@ This is a shared HPC environment used by many researchers. Be conservative,
 respect shared resources, and prefer small, verifiable steps. Consult the
 Alliance documentation before improvising: https://docs.alliancecan.ca
 
-Do not try to be creative by working outside of the practices documented in
-the Alliance documentation. When in doubt, suggest to the user to contact our
-technical support for guidance.
+Do not improvise outside the practices described in the Alliance
+documentation. When in doubt, suggest that the user contact technical support
+for guidance.
+
+Human users remain responsible for the actions of their agents and tools.
 
 ## Keep login-node work lightweight
 
 The current working directory may be on a shared login node. On login nodes,
 limit work to lightweight operations such as editing files, reading code,
-small Git operations, and short commands.
+small Git operations, and short commands. Resource limits are enforced with
+cgroups.
 
 Do not run heavy, long-running, or parallel workloads on a login node. This
 includes large builds, training or inference, large data processing, and
@@ -21,6 +24,9 @@ it is not.
 
 Not all compute nodes have access to the internet. You may need to stage
 tarballs or wheels.
+
+Tools such as VS Code often leave stale processes that can affect other users.
+Point these processes out and offer to terminate them.
 
 ## Use the scheduler for non-trivial work
 
@@ -32,11 +38,17 @@ salloc --account=<account> --time=... --cpus-per-task=1 --mem=1G
 
 Run unattended work through an `sbatch` script. Before starting anything that
 may consume significant CPU, memory, GPU resources, or wall time, stop and ask
-the user to move the work into an interactive job. Request the minimal amount
-of resources necessary to run the job always. Wasting resources impacts other
-users. Limit test jobs. Avoid jobs with run time shorter than 15 minutes, as
-these can be bundled together. Jobs longer than 12 hours should implement
-checkpointing.
+the user to move the work into an interactive job. Always request only the
+resources necessary to run the job; wasting resources affects other users.
+Limit test jobs. Bundle tasks that would otherwise run for less than 15 minutes.
+Jobs longer than 12 hours should implement checkpointing. Specifying
+unnecessary partitions or features will result in longer wait times.
+
+Do not use tight polling loops against Slurm. Wait at least 60 seconds between
+queries, and avoid multiple monitoring loops. Prefer scheduler-native
+mechanisms such as job dependencies.
+
+Never insert sleep commands into jobs.
 
 ## Use the Alliance Python wheelhouse
 
@@ -60,9 +72,10 @@ wheels can be installed via a support ticket with the Alliance.
 
 ## Use the filesystems
 
-Do not try to access files outside of the user's home, project, or scratch. Do
-not try to access files of other users. These are networked filesystems, and
-patterns which write frequently in fast loops are destructive.
+Do not try to access files outside the user's home, project, or scratch. Do
+not try to access other users' files. These are networked filesystems, and
+frequent writes in tight loops can be disruptive. When managing many small
+files, consider containers or aggregate formats such as tar archives or HDF5.
 
 - **home**: Backed up, with a small quota. Use for configuration, source code,
   and small persistent files.
@@ -75,6 +88,12 @@ patterns which write frequently in fast loops are destructive.
 The usual flow is to work in scratch, move cleaned results to project, and
 keep configuration in home. Check `diskusage_report` before large writes. If
 an operation could exhaust quota, stop and inform the user.
+
+`$SLURM_TMPDIR` is available to each job for its duration. Use it for
+I/O-intensive workflows.
+
+Globus is recommended for file transfers. Other options include Open OnDemand,
+`rsync`, and `scp`.
 
 ## Use environment modules
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -48,7 +48,8 @@ packages from the wheelhouse:
 
 ```sh
 module load python/<version>
-python -m venv <venv>
+virtualenv --no-download <venv>
+source <venv>/bin/activate
 pip install --no-index <package>
 ```
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -4,6 +4,10 @@ This is a shared HPC environment used by many researchers. Be conservative,
 respect shared resources, and prefer small, verifiable steps. Consult the
 Alliance documentation before improvising: https://docs.alliancecan.ca
 
+Do not try to be creative by working outside of the practices documented in
+the Alliance documentation. When in doubt, suggest to the user to contact our
+technical support for guidance.
+
 ## Keep login-node work lightweight
 
 The current working directory may be on a shared login node. On login nodes,
@@ -15,15 +19,24 @@ includes large builds, training or inference, large data processing, and
 multi-core or GPU workloads. If unsure whether a task is lightweight, assume
 it is not.
 
+Not all compute nodes have access to the internet. You may need to stage
+tarballs or wheels.
+
 ## Use the scheduler for non-trivial work
 
 For interactive work, request an allocation:
 
-    salloc --account=<account> --time=... --cpus-per-task=... --mem=...
+```sh
+salloc --account=<account> --time=... --cpus-per-task=1 --mem=1G
+```
 
 Run unattended work through an `sbatch` script. Before starting anything that
 may consume significant CPU, memory, GPU resources, or wall time, stop and ask
-the user to move the work into an allocation.
+the user to move the work into an interactive job. Request the minimal amount
+of resources necessary to run the job always. Wasting resources impacts other
+users. Limit test jobs. Avoid jobs with run time shorter than 15 minutes, as
+these can be bundled together. Jobs longer than 12 hours should implement
+checkpointing.
 
 ## Use the Alliance Python wheelhouse
 
@@ -33,25 +46,34 @@ It is a package source, not a replacement for a virtual environment.
 Load an available Python module, create a virtual environment, and install
 packages from the wheelhouse:
 
-    module load python/<version>
-    python -m venv <venv>
-    pip install --no-index <package>
+```sh
+module load python/<version>
+python -m venv <venv>
+pip install --no-index <package>
+```
 
-Prefer the wheelhouse over PyPI. Avoid Conda and arbitrary internet
-installations unless the user explicitly requests otherwise.
+This can also be done within jobs via `$SLURM_TMPDIR`. Prefer the wheelhouse
+over PyPI. Use `requirements.txt` files. Avoid `uv`, Conda, and arbitrary
+internet installations unless the user explicitly requests otherwise. Missing
+wheels can be installed via a support ticket with the Alliance.
 
-## Use the appropriate filesystem
+## Use the filesystems
+
+Do not try to access files outside of the user's home, project, or scratch. Do
+not try to access files of other users. These are networked filesystems, and
+patterns which write frequently in fast loops are destructive.
 
 - **home**: Backed up, with a small quota. Use for configuration, source code,
   and small persistent files.
 - **project**: Backed up and shared with the sponsor or PI group. Use for
   cleaned results intended to persist or be shared.
-- **scratch**: Not backed up and periodically purged. Use for active work, and
-  never keep the only copy of important data there.
+- **scratch**: Not backed up and periodically purged. Used for active work,
+  temporary files, logs, and checkpoints. Never keep the only copy of important
+  data there.
 
 The usual flow is to work in scratch, move cleaned results to project, and
-keep configuration in home. Check quota before large writes. If an operation
-could exhaust quota, stop and inform the user.
+keep configuration in home. Check `diskusage_report` before large writes. If
+an operation could exhaust quota, stop and inform the user.
 
 ## Use environment modules
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,32 +1,20 @@
 # Alliance cluster usage
 
-This is a shared HPC environment used by many researchers. Be conservative,
-respect shared resources, and prefer small, verifiable steps. Consult the
-Alliance documentation before improvising: https://docs.alliancecan.ca
+This is a shared HPC environment used by many researchers. Be conservative, respect shared resources, and prefer small, verifiable steps. Consult the Alliance documentation before improvising: https://docs.alliancecan.ca
 
-Do not improvise outside the practices described in the Alliance
-documentation. When in doubt, suggest that the user contact technical support
-for guidance.
+Do not improvise outside the practices described in the Alliance documentation. When in doubt, suggest that the user contact technical support for guidance.
 
 Human users remain responsible for the actions of their agents and tools.
 
 ## Keep login-node work lightweight
 
-The current working directory may be on a shared login node. On login nodes,
-limit work to lightweight operations such as editing files, reading code,
-small Git operations, and short commands. Resource limits are enforced with
-cgroups.
+The current working directory may be on a shared login node. On login nodes, limit work to lightweight operations such as editing files, reading code, small Git operations, and short commands. Resource limits are enforced with cgroups.
 
-Do not run heavy, long-running, or parallel workloads on a login node. This
-includes large builds, training or inference, large data processing, and
-multi-core or GPU workloads. If unsure whether a task is lightweight, assume
-it is not.
+Do not run heavy, long-running, or parallel workloads on a login node. This includes large builds, training or inference, large data processing, and multi-core or GPU workloads. If unsure whether a task is lightweight, assume it is not.
 
-Not all compute nodes have access to the internet. You may need to stage
-tarballs or wheels.
+Not all compute nodes have access to the internet. You may need to stage tarballs or wheels.
 
-Tools such as VS Code often leave stale processes that can affect other users.
-Point these processes out and offer to terminate them.
+Tools such as VS Code often leave stale processes that can affect other users. Point these processes out and offer to terminate them.
 
 ## Use the scheduler for non-trivial work
 
@@ -36,27 +24,17 @@ For interactive work, request an allocation:
 salloc --account=<account> --time=... --cpus-per-task=1 --mem=1G
 ```
 
-Run unattended work through an `sbatch` script. Before starting anything that
-may consume significant CPU, memory, GPU resources, or wall time, stop and ask
-the user to move the work into an interactive job. Always request only the
-resources necessary to run the job; wasting resources affects other users.
-Limit test jobs. Bundle tasks that would otherwise run for less than 15 minutes.
-Jobs longer than 12 hours should implement checkpointing. Specifying
-unnecessary partitions or features will result in longer wait times.
+Run unattended work through an `sbatch` script. Before starting anything that may consume significant CPU, memory, GPU resources, or wall time, stop and ask the user to move the work into an interactive job. Always request only the resources necessary to run the job; wasting resources affects other users. Limit test jobs. Bundle tasks that would otherwise run for less than 15 minutes. Jobs longer than 12 hours should implement checkpointing. Specifying unnecessary partitions or features will result in longer wait times.
 
-Do not use tight polling loops against Slurm. Wait at least 60 seconds between
-queries, and avoid multiple monitoring loops. Prefer scheduler-native
-mechanisms such as job dependencies.
+Do not use tight polling loops against Slurm. Wait at least 60 seconds between queries, and avoid multiple monitoring loops. Prefer scheduler-native mechanisms such as job dependencies.
 
 Never insert sleep commands into jobs.
 
 ## Use the Alliance Python wheelhouse
 
-The Alliance wheelhouse provides prebuilt, cluster-optimized Python packages.
-It is a package source, not a replacement for a virtual environment.
+The Alliance wheelhouse provides prebuilt, cluster-optimized Python packages. It is a package source, not a replacement for a virtual environment.
 
-Load an available Python module, create a virtual environment, and install
-packages from the wheelhouse:
+Load an available Python module, create a virtual environment, and install packages from the wheelhouse:
 
 ```sh
 module load python/<version>
@@ -65,38 +43,22 @@ source <venv>/bin/activate
 pip install --no-index <package>
 ```
 
-This can also be done within jobs via `$SLURM_TMPDIR`. Prefer the wheelhouse
-over PyPI. Use `requirements.txt` files. Avoid `uv`, Conda, and arbitrary
-internet installations unless the user explicitly requests otherwise. Missing
-wheels can be installed via a support ticket with the Alliance.
+This can also be done within jobs via `$SLURM_TMPDIR`. Prefer the wheelhouse over PyPI. Use `requirements.txt` files. Avoid `uv`, Conda, and arbitrary internet installations unless the user explicitly requests otherwise. Missing wheels can be installed via a support ticket with the Alliance.
 
 ## Use the filesystems
 
-Do not try to access files outside the user's home, project, or scratch. Do
-not try to access other users' files. These are networked filesystems, and
-frequent writes in tight loops can be disruptive. When managing many small
-files, consider containers or aggregate formats such as tar archives or HDF5.
+Do not try to access files outside the user's home, project, or scratch. Do not try to access other users' files. These are networked filesystems, and frequent writes in tight loops can be disruptive. When managing many small files, consider containers or aggregate formats such as tar archives or HDF5.
 
-- **home**: Backed up, with a small quota. Use for configuration, source code,
-  and small persistent files.
-- **project**: Backed up and shared with the sponsor or PI group. Use for
-  cleaned results intended to persist or be shared.
-- **scratch**: Not backed up and periodically purged. Used for active work,
-  temporary files, logs, and checkpoints. Never keep the only copy of important
-  data there.
+- **home**: Backed up, with a small quota. Use for configuration, source code, and small persistent files.
+- **project**: Backed up and shared with the sponsor or PI group. Use for cleaned results intended to persist or be shared.
+- **scratch**: Not backed up and periodically purged. Used for active work, temporary files, logs, and checkpoints. Never keep the only copy of important data there.
 
-The usual flow is to work in scratch, move cleaned results to project, and
-keep configuration in home. Check `diskusage_report` before large writes. If
-an operation could exhaust quota, stop and inform the user.
+The usual flow is to work in scratch, move cleaned results to project, and keep configuration in home. Check `diskusage_report` before large writes. If an operation could exhaust quota, stop and inform the user.
 
-`$SLURM_TMPDIR` is available to each job for its duration. Use it for
-I/O-intensive workflows.
+`$SLURM_TMPDIR` is available to each job for its duration. Use it for I/O-intensive workflows.
 
-Globus is recommended for file transfers. Other options include Open OnDemand,
-`rsync`, and `scp`.
+Globus is recommended for file transfers. Other options include Open OnDemand, `rsync`, and `scp`.
 
 ## Use environment modules
 
-Software is provided through environment modules. Use `module avail` and
-`module load` to discover and activate software. Consult the Alliance
-documentation for setup details rather than guessing.
+Software is provided through environment modules. Use `module avail` and `module load` to discover and activate software. Consult the Alliance documentation for setup details rather than guessing.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,0 +1,60 @@
+# Alliance cluster usage
+
+This is a shared HPC environment used by many researchers. Be conservative,
+respect shared resources, and prefer small, verifiable steps. Consult the
+Alliance documentation before improvising: https://docs.alliancecan.ca
+
+## Keep login-node work lightweight
+
+The current working directory may be on a shared login node. On login nodes,
+limit work to lightweight operations such as editing files, reading code,
+small Git operations, and short commands.
+
+Do not run heavy, long-running, or parallel workloads on a login node. This
+includes large builds, training or inference, large data processing, and
+multi-core or GPU workloads. If unsure whether a task is lightweight, assume
+it is not.
+
+## Use the scheduler for non-trivial work
+
+For interactive work, request an allocation:
+
+    salloc --account=<account> --time=... --cpus-per-task=... --mem=...
+
+Run unattended work through an `sbatch` script. Before starting anything that
+may consume significant CPU, memory, GPU resources, or wall time, stop and ask
+the user to move the work into an allocation.
+
+## Use the Alliance Python wheelhouse
+
+The Alliance wheelhouse provides prebuilt, cluster-optimized Python packages.
+It is a package source, not a replacement for a virtual environment.
+
+Load an available Python module, create a virtual environment, and install
+packages from the wheelhouse:
+
+    module load python/<version>
+    python -m venv <venv>
+    pip install --no-index <package>
+
+Prefer the wheelhouse over PyPI. Avoid Conda and arbitrary internet
+installations unless the user explicitly requests otherwise.
+
+## Use the appropriate filesystem
+
+- **home**: Backed up, with a small quota. Use for configuration, source code,
+  and small persistent files.
+- **project**: Backed up and shared with the sponsor or PI group. Use for
+  cleaned results intended to persist or be shared.
+- **scratch**: Not backed up and periodically purged. Use for active work, and
+  never keep the only copy of important data there.
+
+The usual flow is to work in scratch, move cleaned results to project, and
+keep configuration in home. Check quota before large writes. If an operation
+could exhaust quota, stop and inform the user.
+
+## Use environment modules
+
+Software is provided through environment modules. Use `module avail` and
+`module load` to discover and activate software. Consult the Alliance
+documentation for setup details rather than guessing.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -6,6 +6,14 @@ Do not improvise outside the practices described in the Alliance documentation. 
 
 Human users remain responsible for the actions of their agents and tools.
 
+## Documentation
+
+A read only copy of the Alliance wiki in markdown can be referenced at the following path:
+
+`/cvmfs/soft.computecanada.ca/custom/docs/`.
+
+It contains both an English and Fresh version.
+
 ## Keep login-node work lightweight
 
 The current working directory may be on a shared login node. On login nodes, limit work to lightweight operations such as editing files, reading code, small Git operations, and short commands. Resource limits are enforced with cgroups.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -12,7 +12,7 @@ A read only copy of the Alliance wiki in markdown can be referenced at the follo
 
 `/cvmfs/soft.computecanada.ca/custom/docs/`.
 
-It contains both an English and Fresh version.
+It contains both an English and French version.
 
 ## Keep login-node work lightweight
 


### PR DESCRIPTION
Per request, adds an `AGENTS.md` to the software stack to better direct agents towards best practices and documentation.

Implementation details:
* Claude reads `/etc/claude-code/CLAUDE.md`. This works for users who have installed Claude on the system itself.
* Respects symlinks. Most other harnesses and agents expect a AGENTS.md.
* We should experiment with env vars that claude and codex (gpt/openai) respect to disable dangerous behaviour.

I am open to refining the file and testing things out on Nibi as necessary.