### PR TITLE
Use Lmod 9.4 from gentoo/2026

### DIFF
--- a/profile.d/z-20-lmod.csh
+++ b/profile.d/z-20-lmod.csh
@@ -1,5 +1,5 @@
-setenv MODULESHOME /cvmfs/soft.computecanada.ca/custom/software/lmod/lmod
-source /cvmfs/soft.computecanada.ca/custom/software/lmod/lmod/init/csh
+setenv MODULESHOME /cvmfs/soft.computecanada.ca/gentoo/2026/x86-64-v3/usr/share/Lmod
+source ${MODULESHOME}/init/csh
 setenv LMOD_PACKAGE_PATH /cvmfs/soft.computecanada.ca/config/lmod/
 setenv LMOD_ADMIN_FILE /cvmfs/soft.computecanada.ca/config/lmod/admin.list
 setenv LMOD_AVAIL_STYLE grouped:system

--- a/profile.d/z-20-lmod.sh
+++ b/profile.d/z-20-lmod.sh
@@ -1,4 +1,4 @@
-export MODULESHOME=/cvmfs/soft.computecanada.ca/custom/software/lmod/lmod
+export MODULESHOME=/cvmfs/soft.computecanada.ca/gentoo/2026/x86-64-v3/usr/share/Lmod
 source $MODULESHOME/init/profile
 export LMOD_PACKAGE_PATH=/cvmfs/soft.computecanada.ca/config/lmod/
 export LMOD_ADMIN_FILE=/cvmfs/soft.computecanada.ca/config/lmod/admin.list


### PR DESCRIPTION
We can use this Lmod even from older StdEnv as their are no incompatibilities: Lmod uses its own Tcl and Lua which can be different from the ones in $PATH.

The reason why we used an apptainer installation before is compatibility with CentOS-6 but this is no longer relevant; all glibc's in Gentoo 2020+ are compatible with Linux kernels used by CentOS-7+ (Linux kernel 3.2+).